### PR TITLE
Adaptation des "import" pour la modification d'un nom de fichier

### DIFF
--- a/test_.py
+++ b/test_.py
@@ -1,5 +1,5 @@
-from sommeAPI import ajouter, sommer, vider, supprimer
-import sommeAPI
+from operationsPartie import ajouter, sommer, vider, supprimer
+import operationsPartie
 
 # Exceptions : 
 # 		La vérification syntaxique est effectuée par Flake8
@@ -113,7 +113,5 @@ def test_sommer():
 	assert sommer() != 64
 	# Somme avec règle strike
 	assert sommer() == 71
-
-
 
 


### PR DESCRIPTION
nom du fichier de fonctions (pour une partie de bowling) n'était pas adapté à l'application